### PR TITLE
Tracking in-flight urls in UrlManager instead of relying on timeouts

### DIFF
--- a/lib/crawlie.ex
+++ b/lib/crawlie.ex
@@ -72,8 +72,7 @@ defmodule Crawlie do
     case client.get(url, options) do
       {:ok, body} -> [{page, body}]
       {:error, _reason} ->
-        retried_page = Page.retry(page)
-        UrlManager.add_pages(url_stage, [retried_page])
+        UrlManager.retry_page(url_stage, page)
         []
     end
   end
@@ -99,7 +98,7 @@ defmodule Crawlie do
     if depth < max_depth do
       pages = module.extract_links(url, parsed, options)
         |> Enum.map(&Page.child(page, &1))
-      UrlManager.add_pages(url_stage, pages)
+      UrlManager.add_children_pages(url_stage, pages)
     end
 
     nil

--- a/lib/crawlie.ex
+++ b/lib/crawlie.ex
@@ -72,7 +72,7 @@ defmodule Crawlie do
     case client.get(url, options) do
       {:ok, body} -> [{page, body}]
       {:error, _reason} ->
-        UrlManager.retry_page(url_stage, page)
+        UrlManager.page_failed(url_stage, page)
         []
     end
   end

--- a/lib/crawlie/options.ex
+++ b/lib/crawlie/options.ex
@@ -13,7 +13,6 @@ defmodule Crawlie.Options do
     [
       follow_redirect: true,
       http_client: Crawlie.HttpClient.HTTPoisonClient,
-      url_manager_timeout: 200,
       max_depth: 0,
       max_retries: 3,
       fetch_phase: [

--- a/lib/crawlie/stage/url_manager.ex
+++ b/lib/crawlie/stage/url_manager.ex
@@ -8,6 +8,10 @@ defmodule Crawlie.Stage.UrlManager do
 
   require Logger
 
+  #===========================================================================
+  # State
+  #===========================================================================
+
   defmodule State do
     @type t :: %State{
       # incoming
@@ -105,7 +109,7 @@ defmodule Crawlie.Stage.UrlManager do
   end
 
   #===========================================================================
-  # API Functions
+  # Manager - API Functions
   #===========================================================================
 
   @spec start_link(Stream.t, Keyword.t) :: {:ok, GenStage.stage}
@@ -120,7 +124,14 @@ defmodule Crawlie.Stage.UrlManager do
   end
 
 
-  def add_pages(url_manager_stage, pages) when is_list(pages) do
+  def add_children_pages(url_manager_stage, pages), do: add_pages(url_manager_stage, pages)
+
+  def retry_page(url_manager_stage, failed_page) do
+    page = Page.retry(failed_page)
+    add_pages(url_manager_stage, [page])
+  end
+
+  defp add_pages(url_manager_stage, pages) when is_list(pages) do
     GenStage.cast(url_manager_stage, {:add_pages, pages})
   end
 

--- a/test/crawlie_test.exs
+++ b/test/crawlie_test.exs
@@ -7,7 +7,6 @@ defmodule CrawlieTest do
 
   doctest Crawlie
 
-  @moduletag timeout: 1000
 
   test "with default parser logic and a mock client" do
     opts = Options.with_mock_client(test_opts)


### PR DESCRIPTION
Takes care of https://github.com/nietaki/crawlie/issues/7